### PR TITLE
qca807x: add a LED quirk for Xiaomi AX3600

### DIFF
--- a/qca/qca-ssdk/patches/0009-qca807x-add-a-LED-quirk-for-Xiaomi-AX3600.patch
+++ b/qca/qca-ssdk/patches/0009-qca807x-add-a-LED-quirk-for-Xiaomi-AX3600.patch
@@ -1,0 +1,29 @@
+From 913514b9177e77836f2c8d61fc498b54f54c6775 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 26 Jan 2022 14:47:33 +0100
+Subject: [PATCH] qca807x: add a LED quirk for Xiaomi AX3600
+
+AX3600 requires the same LED quirk so that PHY LED-s will blink even
+once Linux resets the PHY.
+
+So, just check for its compatible.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ src/hsl/phy/malibu_phy.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/src/hsl/phy/malibu_phy.c
++++ b/src/hsl/phy/malibu_phy.c
+@@ -2728,8 +2728,9 @@ malibu_phy_hw_init(a_uint32_t dev_id, a_
+ 			led_status |= MALIBU_LED_1000_CTRL1_100_10_MASK;
+ 			malibu_phy_mmd_write(dev_id, phy_addr, MALIBU_PHY_MMD7_NUM,
+ 				MALIBU_PHY_MMD7_LED_1000_CTRL1, led_status);
+-			if (of_machine_is_compatible("xiaomi,ax9000")) {
+-				/* add 1000M link LED behavior for Xiaomi AX9000 */
++			/* add 1000M link LED behavior for Xiaomi boards */
++			if (of_machine_is_compatible("xiaomi,ax9000") ||
++			    of_machine_is_compatible("xiaomi,ax3600")) {
+ 				led_status = malibu_phy_mmd_read(dev_id, phy_addr, MALIBU_PHY_MMD7_NUM,
+ 					MALIBU_PHY_MMD7_LED_100_CTRL1);
+ 				led_status &= ~MALIBU_LED_100_CTRL1_1000_MASK;


### PR DESCRIPTION
AX3600 requires the same LED quirk so that PHY LED-s will blink even
once Linux resets the PHY.

So, just check for its compatible.

Signed-off-by: Robert Marko <robimarko@gmail.com>